### PR TITLE
Bump mlrun version to 0.9.3

### DIFF
--- a/quick-start/assets/mlrunkit_install.py
+++ b/quick-start/assets/mlrunkit_install.py
@@ -40,13 +40,13 @@ def main():
 def _parse_args():
     parser = argparse.ArgumentParser(description="Install MLRun Kit interactively")
 
-    parser.add_argument("--chart-version", type=str, default="0.1.1")
+    parser.add_argument("--chart-version", type=str, default="0.1.16")
     parser.add_argument("--registry-url", type=str, default="localhost:5000")
     parser.add_argument("--timeout", type=str, default="10m")
     parser.add_argument("--namespace", type=str, default="mlrun")
     parser.add_argument("--nuclio-ui-url", type=str, default="http://localhost:30050")
     parser.add_argument("--mlrun-ui-url", type=str, default="http://localhost:30060")
-    parser.add_argument("--jupyter-image-tag", type=str, default="0.6.0")
+    parser.add_argument("--jupyter-image-tag", type=str, default="0.9.3")
     return parser.parse_args()
 
 

--- a/quick-start/background.sh
+++ b/quick-start/background.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MLRUN_VERSION=0.6.0
+MLRUN_VERSION=0.9.3
 
 # TODO: change to MLRUN_VERSION once 0.6.1 is out
-docker pull quay.io/mlrun/jupyter:0.6.1-rc2-jupy
+docker pull quay.io/mlrun/jupyter:${MLRUN_VERSION}
 docker pull mlrun/mlrun-api:${MLRUN_VERSION}
 docker pull mlrun/mlrun-ui:${MLRUN_VERSION}
 docker pull mlrun/ml-models:${MLRUN_VERSION}

--- a/quick-start/background.sh
+++ b/quick-start/background.sh
@@ -16,8 +16,7 @@
 
 MLRUN_VERSION=0.9.3
 
-# TODO: change to MLRUN_VERSION once 0.6.1 is out
 docker pull quay.io/mlrun/jupyter:${MLRUN_VERSION}
 docker pull mlrun/mlrun-api:${MLRUN_VERSION}
 docker pull mlrun/mlrun-ui:${MLRUN_VERSION}
-docker pull mlrun/ml-models:${MLRUN_VERSION}
+docker pull mlrun/mlrun:${MLRUN_VERSION}

--- a/quick-start/helm_charts.md
+++ b/quick-start/helm_charts.md
@@ -14,11 +14,10 @@ Next, Install MLRun Kit chart:
 
 ```shell
 python3 /usr/local/bin/mlrunkit_install.py \
-    --chart-version 0.1.1 \
+    --chart-version 0.1.16 \
     --registry-url ${REGISTRY} \
     --nuclio-ui-url https://[[HOST_SUBDOMAIN]]-30050-[[KATACODA_HOST]].[[KATACODA_DOMAIN]] \
     --mlrun-ui-url https://[[HOST_SUBDOMAIN]]-30060-[[KATACODA_HOST]].[[KATACODA_DOMAIN]] \
-    --jupyter-image-tag 0.6.1-rc2-jupy
 ```{{execute}}
 
 >**Note**: Installing MLRun Kit might take several minutes.


### PR DESCRIPTION
MLRun kit should be upgraded to be more advanced on katacoda.
I created a new MLRun-kit chart to support k8s v1.18 because katacoda only supports k8s up to 1.18 at the moment.
After https://github.com/v3io/helm-charts/pull/701 is merged, merge this PR.